### PR TITLE
Add homebrew-services support to the shotty Formula

### DIFF
--- a/Formula/shotty.rb
+++ b/Formula/shotty.rb
@@ -9,4 +9,35 @@ class Shotty < Formula
   def install
     bin.install "bin/shotty"
   end
+
+  def plist
+    <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>net.nevercraft.shotty</string>
+          <key>WatchPaths</key>
+          <array>
+            <string>#{ENV.fetch("HOME")}/Desktop</string>
+          </array>
+          <key>ExitTimeOut</key>
+          <integer>0</integer>
+          <key>ThrottleInterval</key>
+          <integer>1</integer>
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>PATH</key>
+            <string>/usr/local/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/bin:/bin</string>
+          </dict>
+          <key>ProgramArguments</key>
+          <array>
+            <string>/usr/local/bin/shotty</string>
+            <string>mv-last-screenshot</string>
+          </array>
+        </dict>
+      </plist>
+    EOS
+  end
 end


### PR DESCRIPTION
Allows you to use `brew services` to manage the plist and start/stop the shotty service instead of doing it manually via `launchctl`.